### PR TITLE
Fix truncated 'Programming Paradigms'

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ Some recently famous; others highly influential.
 
     * [Programming Abstractions](https://see.stanford.edu/Course/CS106B)
 
-    * [Programming Pa](https://see.stanford.edu/Course/CS107)
+    * [Programming Paradigms](https://see.stanford.edu/Course/CS107)
 
     * These lectures will really push you. And if you are up for it do the assignments too.
 


### PR DESCRIPTION
It seems that in the commit which updated the links to the Stanford lectures (2c3ae45fe393eba26070ed82d2fd38673b863040), the 'Paradigms' was accidentally truncated